### PR TITLE
passwordEncoder 오류 수정 및 Exception 추가

### DIFF
--- a/src/main/java/com/example/miniproject/exception/ExceptionAdvisor.java
+++ b/src/main/java/com/example/miniproject/exception/ExceptionAdvisor.java
@@ -3,22 +3,40 @@ package com.example.miniproject.exception;
 import com.example.miniproject.dto.http.DefaultRes;
 import com.example.miniproject.dto.http.StatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @ControllerAdvice
 @RestController
 public class ExceptionAdvisor {
 
-    // IllegalArgumentException 예외 처리
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<Object> handleIllegalArgumentException(IllegalArgumentException ex) {
+    // IllegalArgumentException & NullPointerException 예외 처리
+    @ExceptionHandler(value = {IllegalArgumentException.class,
+                               NullPointerException.class,
+                               IllegalStateException.class})
+    public ResponseEntity<Object> handleIllegalArgumentException(Exception ex) {
         String errorMsg = ex.getMessage();
 
         return ResponseEntity.badRequest().body(DefaultRes.res(StatusCode.BAD_REQUEST, errorMsg));
 
     }
 
+    // 아이디, 비밀번호 유효성 검사 시 에러
+    @ExceptionHandler(value = {MethodArgumentNotValidException.class})
+    public ResponseEntity<Object> handleValidException(MethodArgumentNotValidException ex) {
+        BindingResult bindingResult = ex.getBindingResult();
+        Map<String, String> errorMap = new HashMap<>();
+        for (FieldError fieldError : bindingResult.getFieldErrors()) {
+            errorMap.put(fieldError.getField(), fieldError.getDefaultMessage());
+        }
 
+        return ResponseEntity.badRequest().body(DefaultRes.res(StatusCode.BAD_REQUEST, null, errorMap));
+    }
 }

--- a/src/main/java/com/example/miniproject/service/BoardService.java
+++ b/src/main/java/com/example/miniproject/service/BoardService.java
@@ -14,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.security.auth.message.AuthException;
 import java.io.IOException;
 import java.util.List;
 
@@ -38,7 +39,7 @@ public class BoardService {
             return ResponseEntity.ok(boardResponseDto);
         }
 
-        return ResponseEntity.badRequest().body(new MsgAndHttpStatusDto("이미지 파일을 업로드해주세요.", HttpStatus.BAD_REQUEST.value()));
+        throw new IllegalArgumentException("이미지 파일을 업로드해주세요");
     }
 
     @Transactional(readOnly = true)
@@ -95,14 +96,15 @@ public class BoardService {
         );
 
         if (!board.getUser().getUserId().equals(userDetails.getUser().getUserId())) {
-            return ResponseEntity.badRequest().body(new MsgAndHttpStatusDto("본인이 작성한 글만 삭제 가능합니다.", HttpStatus.FORBIDDEN.value()));
+            throw new IllegalArgumentException("본인이 작성한 글만 삭제할 수 있습니다.");
         }
+
         String imgPath = board.getImage();
         if (s3Uploader.delete(imgPath)) { // S3 에서 이미지 파일 삭제가 성공하면 DB에 있는 게시글도 삭제
             boardRepository.delete(board);
             return ResponseEntity.ok(new MsgAndHttpStatusDto("삭제 완료!", HttpStatus.OK.value()));
         }
 
-        return ResponseEntity.ok(new MsgAndHttpStatusDto("삭제 실패!", HttpStatus.INTERNAL_SERVER_ERROR.value()));
+        throw new IllegalArgumentException("삭제에 실패했습니다.");
     }
 }

--- a/src/main/java/com/example/miniproject/service/UserService.java
+++ b/src/main/java/com/example/miniproject/service/UserService.java
@@ -37,7 +37,7 @@ public class UserService {
         System.out.println(user.getPassword());
 
         if (!passwordEncoder.matches(password,user.getPassword())) {
-            throw new IllegalStateException("비밀번호가 일치하지 않습니다.");
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
         }
 
         String accessToken = jwtUtil.createAccessToken(user.getUserId());

--- a/src/main/java/com/example/miniproject/service/UserService.java
+++ b/src/main/java/com/example/miniproject/service/UserService.java
@@ -31,14 +31,14 @@ public class UserService {
         String password = loginRequestDto.getPassword();
 
         User user = userRepository.findByUserId(userId).orElseThrow(
-                () -> new IllegalArgumentException("넌 오류야야야ㅑ"));// 예외처리 해주기
+                () -> new IllegalArgumentException("가입하지 않은 회원입니다."));// 예외처리 해주기
 
         System.out.println(password);
         System.out.println(user.getPassword());
 
-//        if (!passwordEncoder.matches(password,user.getPassword())) {
-//            throw new IllegalStateException("난 오류야야야야");
-//        }
+        if (!passwordEncoder.matches(password,user.getPassword())) {
+            throw new IllegalStateException("비밀번호가 일치하지 않습니다.");
+        }
 
         String accessToken = jwtUtil.createAccessToken(user.getUserId());
         String refreshToken = jwtUtil.createRefreshToken(user.getUserId());
@@ -70,7 +70,7 @@ public class UserService {
         if(userRepository.existsByUserId(userId)){
             throw new IllegalStateException("아이디 중복확인을 해주세요.");
         }
-        User user = new User(userId,passwordEncoder.encode(password),nickname,name);
+        User user = new User(userId,password,nickname,name);
         userRepository.save(user);
     }
 }


### PR DESCRIPTION
1. 로그인 시 passwordEncoder.matches() 로 비교해도 예상과 다른 결과가 나오던 문제가 있었습니다.
코드 확인 결과 회원 가입 쪽에서 암호화를 2중으로 하고 있어 이런 결과가 나와 암호화를 1번만 하는 것으로 변경하였습니다.

2. 회원가입 시 아이디, 비밀번호 유효성 검사에서 통과 못 할 경우 발생하는 exception 도 ExceptionAdvisor 에서 핸들링 하도록 코드 추가했습니다.