### PR TITLE
JWT 인증 실패 시 발생하는 예외 핸들링

### DIFF
--- a/src/main/java/com/example/miniproject/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/miniproject/config/WebSecurityConfig.java
@@ -4,6 +4,7 @@ import com.example.miniproject.config.jwt.JwtAuthenticationFilter;
 import com.example.miniproject.config.jwt.JwtUtil;
 import com.example.miniproject.config.oauth.OAuth2AuthenticationSuccessHandler;
 import com.example.miniproject.config.oauth.UserOAuth2Service;
+import com.example.miniproject.config.security.CustomAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
@@ -38,6 +39,7 @@ public class WebSecurityConfig {
     private final JwtUtil jwtUtil;
     private final UserOAuth2Service userOAuth2Service;
     private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
@@ -69,6 +71,9 @@ public class WebSecurityConfig {
                 .successHandler(oAuth2AuthenticationSuccessHandler) // 인증 프로세서에 따라 사용자 정의로직을 실행
                 .userInfoEndpoint()
                 .userService(userOAuth2Service); // 로그인이 성공하면 해당 유저의 정보를 들고 userOAuth2Service에서 후처리를 해주겠다는의미.
+
+        // 401 에러 핸들링
+        http.exceptionHandling().authenticationEntryPoint(customAuthenticationEntryPoint);
 
         return http.build();
     }

--- a/src/main/java/com/example/miniproject/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/miniproject/config/jwt/JwtAuthenticationFilter.java
@@ -28,7 +28,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 
         if (accessToken != null) {
-            String userId = jwtUtil.getUserInfoFromToken(accessToken).getSubject();
 
             if (jwtUtil.validateToken(accessToken, jwtUtil.getAccessKey())) {
                 this.setAuthentication(accessToken);
@@ -37,6 +36,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
                 boolean isRefreshToken = jwtUtil.existsRefreshToken(refreshToken);
                 if (validateRefreshToken && isRefreshToken) {
+                    String userId = jwtUtil.getUserInfoFromToken(accessToken).getSubject();
                     /// 토큰 발급
                     String newAccessToken = jwtUtil.createAccessToken(userId);
                     /// 헤더에 어세스 토큰 추가

--- a/src/main/java/com/example/miniproject/config/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/miniproject/config/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,27 @@
+package com.example.miniproject.config.security;
+
+import com.example.miniproject.dto.http.DefaultRes;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        String json = new ObjectMapper().writeValueAsString(DefaultRes.res(HttpStatus.UNAUTHORIZED.value(), "토큰이 유효하지 않습니다"));
+        response.getWriter().write(json);
+    }
+}


### PR DESCRIPTION
커스텀 엔트리 포인트를 추가해 ExceptionAdvisor에서 내보내는 양식과 동일한 양식으로 예외 메시지를 던지도록 했습니다.